### PR TITLE
add func to search number from phonebook

### DIFF
--- a/gsm.c
+++ b/gsm.c
@@ -950,4 +950,55 @@ bool gsm_ussd(char *command, char *answer, uint16_t sizeOfAnswer, uint8_t waitSe
   }
 }
 //###############################################################################################################
-
+bool gsm_getPhonebookNumber(uint16_t index, char* getnumber)
+{
+	if (getnumber == NULL)
+	{
+		gsm_printf("[GSM] getPhonebookNumber(%d) failed!\r\n", index);
+		return false;
+	}
+	if (gsm_lock(10000) == false)
+	{
+		gsm_printf("[GSM] getPhonebookNumber(%d) failed!\r\n", index);
+	  return false;
+	}
+	char str[32];
+	sprintf(str, "AT+CPBR=%d\r\n", index);
+	if (gsm_command(str, 5000, (char* )gsm.buffer, sizeof(gsm.buffer), 3, "\r\n+CPBR:", "\r\nOK\r\n", "\r\nERROR\r\n")
+		!= 1)
+	{
+		gsm_printf("[GSM] getPhonebookNumber(%d) failed!\r\n", index);
+		gsm_unlock();
+		return false;
+	}
+	sscanf((char*)gsm.buffer, "%*[^\"]\"%[^\"]", getnumber);
+	gsm_printf("[GSM] getPhonebookNumber(%d) done\r\n", index);
+	gsm_unlock();
+	return true;
+}
+//###############################################################################################################
+bool gsm_isNumberExistInPhonebook(char* number, uint8_t from, uint8_t to)
+{
+	if (number == NULL)
+	{
+		gsm_printf("[GSM] getPhonebookNumber() failed!\r\n");
+		return false;
+	}
+	char buffer[32] = {};
+	for (uint16_t index = from; index <= to; index++)
+	{
+		if (gsm_getPhonebookNumber(index, buffer) != 1)
+		{
+			gsm_printf("[GSM] gsm_isNumberExistInPhonebook(%d) failed!\r\n", index);
+			return false;
+		}
+		if (strcmp(number, buffer) == 0)
+		{
+			gsm_printf("[GSM] gsm_isNumberExistInPhonebook(%d) done!\r\n", index);
+			return true;
+		}
+	}
+	gsm_printf("[GSM] gsm_isNumberExistInPhonebook() failed!\r\n");
+	return false;
+}
+//###############################################################################################################

--- a/gsm.h
+++ b/gsm.h
@@ -229,6 +229,8 @@ bool            gsm_tonePlay(gsm_tone_t gsm_tone_, uint32_t durationMiliSecond, 
 bool            gsm_toneStop(void);
 bool            gsm_dtmf(char *string, uint32_t durationMiliSecond);
 bool            gsm_ussd(char *command, char *answer, uint16_t sizeOfAnswer, uint8_t waitSecond);
+bool 		        gsm_isNumberExistInPhonebook(char* number, uint8_t from, uint8_t to);
+bool 		        gsm_getPhonebookNumber(uint16_t index, char* getnumber);
 //###############################################################################################################
 bool            gsm_call_answer(void);
 bool            gsm_call_dial(const char *number, uint8_t waitSecond);


### PR DESCRIPTION
Functions have been added to search for a number by index in the simcard phonebook, and to check for the existence of a number in the book.

`bool gsm_getPhonebookNumber(uint16_t index, char* getnumber);`
Takes the index of the number in the phonebook, and the buffer into which the number located by the index will be written.

`bool gsm_isNumberExistInPhonebook(char* number, uint8_t from, uint8_t to);
`
Takes a number string, and a range to search the book.
Returns true if the number is found in the book. False if not found.

Functions can be useful if the sim800 module must respond only to the numbers that are in the address book. In my case it is used for gps tracker.